### PR TITLE
kwon: todo.jsx에서 에러로 인한 h3 태그 삭제

### DIFF
--- a/rootfit_front/src/home/component/todo.jsx
+++ b/rootfit_front/src/home/component/todo.jsx
@@ -74,12 +74,10 @@ const Todo = () => {
                     <div className='post-meta'>
                       <span className='date'>{todoState.formattedDate}</span>{' '}
                     </div>
-                    <h3>
-                      <h2>오늘의 목표!</h2>
-                    </h3>
+                    <h2>오늘의 목표!</h2>
                     {/* CheckboxList 컴포넌트. */}
                     <div className='row'>
-                    <CheckboxList disabled={true}/>
+                      <CheckboxList disabled={true} />
                     </div>
                     <br />
                     <br />


### PR DESCRIPTION
1. 헬스리스트 '오늘의 목표!' 문구에서 h3 관련 에러 발생으로 h3 태그를 삭제하였습니다.